### PR TITLE
feat: add dynamic cover photo selection to home page

### DIFF
--- a/src/app/[lang]/(dashboard)/home/page.tsx
+++ b/src/app/[lang]/(dashboard)/home/page.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { useState } from "react";
+
 interface Category {
   label: string;
   img: string;
@@ -18,10 +22,41 @@ const categories: Category[] = [
   { label: "Vitra", img: "/assets/vitra.jpg" },
 ];
 
+const coverImages = [
+  "https://static.vecteezy.com/system/resources/previews/037/349/562/non_2x/ai-generated-a-blue-sofa-and-a-wooden-table-free-photo.jpg",
+  "https://www.brillianthomeliving.com.au/cdn/shop/files/Furniture_Protection_1000x500_0096b3ca-3d38-4df1-af60-86024ce54e0b.jpg?v=1658799058&width=2084",
+  "https://www.covermyfurniture.com/wp-content/uploads/2022/08/blue-sofa-3.jpg",
+];
+
 function Home(): JSX.Element {
+  const [mainImage, setMainImage] = useState<string>(coverImages[0]);
+
+  const handleDotClick = (img: string) => {
+    setMainImage(img);
+  };
+
   return (
     <div className="text-center space-y-10 mb-10">
-      <img src="/assets/furniture.jpg" alt="Furniture logo" className="max-w-full h-auto" />
+      <div className="relative">
+        <img
+          src={mainImage}
+          alt="Main cover image"
+          className="w-full h-full object-cover"
+        />
+
+        <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 flex space-x-4">
+          {coverImages.map((img, index) => (
+            <div
+              key={index}
+              className={`w-3 h-3 border-2 rounded-full cursor-pointer transition-all duration-300 ${
+                mainImage === img ? "bg-white" : "border-white"
+              }`}
+              onClick={() => handleDotClick(img)}
+            />
+          ))}
+        </div>
+      </div>
+
       <div className="grid grid-cols-2 gap-5 sm:grid-cols-2 md:grid-cols-6">
         {categories.map((category) => (
           <a
@@ -29,7 +64,11 @@ function Home(): JSX.Element {
             className="block rounded-lg overflow-hidden shadow-lg cursor-pointer"
             key={category.label}
           >
-            <img src={category.img} alt={`Category: ${category.label}`} className="w-auto h-full object-contain hover:scale-105 transition-transform duration-300" />
+            <img
+              src={category.img}
+              alt={`Category: ${category.label}`}
+              className="w-auto h-full object-contain hover:scale-105 transition-transform duration-300"
+            />
             <div className="bg-black bg-opacity-60 text-white text-center p-2 ">
               {category.label}
             </div>

--- a/src/app/components/Header/Header.css
+++ b/src/app/components/Header/Header.css
@@ -145,13 +145,13 @@ button {
   cursor: pointer;
   padding: 0.7em 1.3em;
   border-radius: 5px;
-  border: 1px solid #d3d1d1;
+  /* border: 1px solid #d3d1d1; */
 }
 
 .logout {
   background-color: transparent;
   color: #d3d1d1;
-  border: px solid #d3d1d1;
+  /* border: 1px solid #d3d1d1; */
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 


### PR DESCRIPTION
## Summary:
- Updated the home page to include multiple cover photo options.
- Implemented dot navigation below the cover photo that allows users to select a different cover photo.
- The selected photo is displayed with an indicator that highlights the active dot.

## Changes:
- Added `useState` for managing the selected cover photo.
- Used `absolute` positioning for the navigation dots to place them on the cover photo.
- Added logic to highlight the selected dot with a white border.
- Updated the image URLs to include the new cover photo options.
